### PR TITLE
SLNPPFLDatenAenderung

### DIFF
--- a/Koha/Plugin/Com/Theke/SLNP.pm
+++ b/Koha/Plugin/Com/Theke/SLNP.pm
@@ -461,6 +461,13 @@ sub check_configuration {
             push @errors, 'extra_fee_debit_type_not_set';
         }
 
+        if ( $configuration->{accepted_afl_notice} ) {
+            push @errors, 'no_ILLDefaultStaffEmail'
+                unless C4::Context->preference('ILLDefaultStaffEmail');
+            push @errors, 'no_AFL_ORDER_CREATED'
+                unless Koha::Notice::Templates->search( { code => 'AFL_ORDER_CREATED' } )->count;
+        }
+
         eval { $configuration = YAML::XS::Load( Encode::encode_utf8( $self->retrieve_data('configuration') ) ); };
         push @errors, "Error parsing YAML configuration ($@)"
             if $@;

--- a/Koha/Plugin/Com/Theke/SLNP/configure.tt
+++ b/Koha/Plugin/Com/Theke/SLNP/configure.tt
@@ -48,9 +48,11 @@
                 [% SWITCH error %]
                 [% CASE 'ILLModule_disabled' %]<span>[% strings.missing_syspref | html %] (<a href="/cgi-bin/koha/admin/preferences.pl?op=search&searchfield=ILLModule" target="_blank">ILLModule<a>)</span>
                 [% CASE 'CirculateILL_disabled' %]<span>[% strings.missing_syspref | html %] (<a href="/cgi-bin/koha/admin/preferences.pl?op=search&searchfield=CirculateILL" target="_blank">CirculateILL<a>)</span>
+                [% CASE 'no_ILLDefaultStaffEmail' %]<span>[% strings.missing_syspref | html %] (<a href="/cgi-bin/koha/admin/preferences.pl?op=search&searchfield=ILLDefaultStaffEmail" target="_blank">ILLDefaultStaffEmail<a>)</span>
                 [% CASE 'no_ILL_PARTNER_RET' %]<span>[% strings.missing_letter | html %] (ILL_PARTNER_RET)</span>
                 [% CASE 'no_ILL_RECEIVE_SLIP' %]<span>[% strings.missing_letter | html %] (ILL_RECEIVE_SLIP)</span>
                 [% CASE 'no_ILL_PARTNER_LOST' %]<span>[% strings.missing_letter | html %] (ILL_PARTNER_LOST)</span>
+                [% CASE 'no_AFL_ORDER_CREATED' %]<span>[% strings.missing_letter | html %] (AFL_ORDER_CREATED)</span>
                 [% CASE 'no_fee_debit_type' %]<span>[% strings.bad_configuration | html %]: fee_debit_type</span>
                 [% CASE 'no_extra_fee_debit_type' %]<span>[% strings.bad_configuration | html %]: extra_fee_debit_type</span>
                 [% CASE 'fee_debit_type_not_set' %]<span>[% strings.config_entry_not_set | html %]: fee_debit_type</span>

--- a/Koha/Plugin/Com/Theke/SLNP/intra-includes/receive.inc
+++ b/Koha/Plugin/Com/Theke/SLNP/intra-includes/receive.inc
@@ -87,7 +87,7 @@
       <ol>
         <li>
           <label for="item_callnumber">[% whole.strings.item_callnumber | html %]:</label>
-          <input type="text" size="50" name="item_callnumber" id="item_callnumber" value="[% whole.value.item.itemcallnumber | html %]" />
+          <input type="text" size="50" name="item_callnumber" id="item_callnumber" value="[% IF whole.value.callnumber %][% whole.value.callnumber | html %][% ELSE %][% whole.value.item.itemcallnumber | html %][% END %]" />
         </li>
 
         <li>
@@ -175,6 +175,11 @@
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         $('#lending_library').select2();
+
+        [% IF whole.value.selected_lending_library_id %]
+        $('#lending_library').val('[% whole.value.selected_lending_library_id | html %]');
+        $('#lending_library').trigger('change');
+        [% END %]
 
         function Dopop(link) {
             var newin = window.open(link, 'popup', 'width=600,height=400,resizable=1,toolbar=0,scrollbars=1,top');

--- a/Koha/Plugin/Com/Theke/SLNP/lib/SLNP/Backend.pm
+++ b/Koha/Plugin/Com/Theke/SLNP/lib/SLNP/Backend.pm
@@ -336,12 +336,14 @@ sub metadata {
     my ( $self, $request ) = @_;
 
     my %map = (
-        'Article_author' => 'article_author',    # used alternatively to 'Author'
-        'Article_title'  => 'article_title',     # used alternatively to 'Title'
-        'Author'         => 'author',
-        'ISBN'           => 'isbn',
-        'Order ID'       => 'zflorderid',
-        'Title'          => 'title',
+        'Article_author'  => 'article_author',  # used alternatively to 'Author'
+        'Article_title'   => 'article_title',   # used alternatively to 'Title'
+        'Author'          => 'author',
+        'ISBN'            => 'isbn',
+        'Order ID'        => 'zflorderid',
+        'Title'           => 'title',
+        'Lending_library' => 'lending_library',
+        'Sigel_lending_library' => 'sigel_lending_library',
     );
 
     my %attr;
@@ -362,8 +364,31 @@ sub metadata {
         delete $attr{Article_title};
     }
 
+    # lending library is the borrowernumber
+    if ( $attr{Lending_library} && length( $attr{Lending_library} ) ) {
+        my $lending_library = Koha::Patrons->find( $attr{Lending_library} );
+        if ($lending_library) {
+            $attr{Lending_library} =
+                $lending_library->surname . " "
+              . $lending_library->firstname
+              . (
+                $lending_library->othernames
+                ? " (" . $lending_library->othernames . ")"
+                : ""
+              );
+        }
+    }
+    elsif ( $attr{Sigel_lending_library} ) {
+        # Sigel_lending_library is the original value from SLNP
+        # show unless lending_library is set
+        $attr{Lending_library} = $attr{Sigel_lending_library};
+    }
+
+    delete( $attr{Sigel_lending_library} ) if ( $attr{Sigel_lending_library} );
+
     return \%attr;
 }
+
 
 =head3 create
 
@@ -546,6 +571,50 @@ sub receive {
 
         $self->{logger}->error("No patrons defined as lending libraries (categorycode=$partner_category_code)")
             unless $lending_libraries->count > 0;
+
+        # search in attributes for lending_library
+        # it is usually given as ISIL like 'DE-123' or like Sigel '714'
+        my $selected_lending_library_isil = $request->extended_attributes->search({ type => 'sigel_lending_library' })->next;
+
+        if ($selected_lending_library_isil) {
+
+            # if ISIL/Sigel is wrapped <...>
+            my $search_prefix =
+              $self->{configuration}->{lending_library}->{search_prefix} // "";
+            my $search_suffix =
+              $self->{configuration}->{lending_library}->{search_suffix} // "";
+
+            # patron db column in which the ISIL/Sigel is saved
+            my $ill_library_id_column =
+              $self->{configuration}->{lending_library}->{ill_library_id}
+              // "othernames";
+
+            if (
+                grep( /^$ill_library_id_column$/,
+                    ( 'surname', 'firstname', 'middle_name', 'othernames' ) )
+              )
+            {
+                my $patron_query = "%". $search_prefix. $selected_lending_library_isil->value. $search_suffix . "%";
+
+                my $selected_lending_library = Koha::Patrons->search( { $ill_library_id_column => { "like" => $patron_query }, categorycode => $partner_category_code })->single;
+
+                if ($selected_lending_library) {
+                    $template_params->{selected_lending_library_id} =
+                      $selected_lending_library->borrowernumber;
+                }
+            }
+
+        }
+
+
+        # callnumber
+        my $callnumber =
+          $request->extended_attributes->search( { type => 'shelfmark' } )
+          ->next;
+        if ($callnumber) {
+            $template_params->{callnumber} = $callnumber->value;
+        }
+        
 
         $template_params->{received_on_date}  = dt_from_string;
         $template_params->{lending_libraries} = $lending_libraries;

--- a/Koha/Plugin/Com/Theke/SLNP/lib/SLNP/Commands/DatenAenderung.pm
+++ b/Koha/Plugin/Com/Theke/SLNP/lib/SLNP/Commands/DatenAenderung.pm
@@ -1,0 +1,208 @@
+package SLNP::Commands::DatenAenderung;
+
+#
+# This file is part of Koha.
+#
+# Koha is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# Koha is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Koha; if not, see <http://www.gnu.org/licenses>.
+
+use Modern::Perl;
+
+use utf8;
+
+use C4::Context;
+
+use C4::Circulation;
+use C4::Reserves;
+
+use Koha::Database;
+
+use Koha::Biblios;
+use Koha::DateUtils qw(dt_from_string);
+use Koha::ILL::Requests;
+use Koha::Plugin::Com::Theke::SLNP;
+use Koha::SearchEngine::Search;
+
+use List::MoreUtils qw(any uniq);
+use Scalar::Util    qw(blessed);
+use Try::Tiny;
+
+use SLNP::Exceptions;
+
+=head1 NAME
+
+SLNP::Commands::DatenAenderung - Class for handling DatenAenderung (PFL) commands
+
+=head1 API
+
+=head2 Methods
+
+=cut
+
+=head3 SLNPPFLDatenAenderung
+
+Main command to be run from the server.
+
+=cut
+
+sub SLNPPFLDatenAenderung {
+    my ( $cmd, $params ) = @_;
+
+    my $configuration = Koha::Plugin::Com::Theke::SLNP->new->configuration;
+
+    if ( $cmd->{'req_valid'} == 1 ) {
+
+# strip $configuration->{pfl_number_prefix}
+# when pfl_number_prefix is set to "@" the zfl server omits it on the DatenAenderung request.
+
+        if (
+            (
+                   $configuration->{pfl_number_prefix} eq "@"
+                && $params->{PFLNummer} =~ /^(\d*)$/
+            )
+            || $params->{PFLNummer} =~
+            /^$configuration->{pfl_number_prefix}(\d*)$/
+          )
+
+        {
+            my $illrequest_id = $1;
+
+            my $illrequest = Koha::ILL::Requests->find($illrequest_id);
+
+            return request_rejected( $cmd, 'SLNP_PFL_NOT_EXISTING',
+                "PFL-Nummer nicht vorhanden" )
+              unless ($illrequest);
+
+            my $slnp_illbackend =
+              $illrequest->load_backend("SLNP");    # this is still $illrequest
+
+            my $args              = {};
+            my $attribute_mapping = attribute_mapping();
+            foreach my $attribute ( keys %{$attribute_mapping} ) {
+                if ( defined $params->{$attribute}
+                    && length( $params->{$attribute} ) )
+                {
+                    $args->{ $attribute_mapping->{$attribute} } =
+                      $params->{$attribute};
+                }
+            }
+
+            while ( my ( $type, $value ) = each %{$args} ) {
+                my $attr = $illrequest->extended_attributes->find(
+                    {
+                        type => $type
+                    }
+                );
+
+                if ($attr) {    # update
+                    if ( $attr->value ne $value ) {
+                        $attr->update( { value => $value, } );
+                    }
+                }
+                else {          # new
+                    $attr = Koha::ILL::Request::Attribute->new(
+                        {
+                            illrequest_id => $illrequest_id,
+                            type          => $type,
+                            value         => $value,
+                        }
+                    )->store;
+                }
+
+            }
+        }
+        else {
+            return request_rejected( $cmd, 'SLNP_PFL_NOT_PLAUSIBLE',
+                "PFL-Nummer ist nicht plausibel!" );
+        }
+    }
+    return $cmd;
+}
+
+=head3 attribute_mapping
+
+Simple SLNP -> Koha ILL request attribute mapping.
+
+=cut
+
+sub attribute_mapping {
+    return {
+        AufsatzAutor   => 'article_author',
+        AufsatzTitel   => 'article_title',
+        AusgabeOrt     => 'pickup_location_description',
+        Band           => 'volume',
+        Bemerkung      => 'notes',
+        BenutzerNummer => 'cardnumber',
+        BestellId      => 'zflorderid',
+        EJahr          => 'year',
+        Info           => 'info',
+        Isbn           => 'isbn',
+        Issn           => 'issn',
+        Seitenangabe   => 'pages',
+        Signatur       => 'shelfmark',
+        Titel          => 'title',
+        Verfasser      => 'author',
+        Verlag         => 'publisher',
+        Auflage        => 'issue',                         # copy case
+        Heft           => 'issue',                         # loan case
+        SigelGB        => 'sigel_lending_library',
+        ErledFrist     => 'due_date',
+    };
+}
+
+=head3 request_accepted
+
+    request_accepted( $cmd, $pflnummer );
+
+Helper method that makes I<$cmd> carry the right information for a successful request.
+
+=cut
+
+sub request_accepted {
+    my ( $cmd, $pflnummer ) = @_;
+
+    $cmd->{rsp_para}->[0] = {
+        resp_pnam => 'PFLNummer',
+        resp_pval => $pflnummer,
+    };
+
+    $cmd->{rsp_para}->[1] = {
+        resp_pnam => 'OKMsg',
+        resp_pval => 'Bestellung wird bearbeitet',
+    };
+
+    return $cmd;
+}
+
+=head3 request_rejected
+
+    request_rejected( $cmd, $type, $text );
+
+Helper method that makes I<$cmd> carry the right information for a rejected request.
+
+=cut
+
+sub request_rejected {
+    my ( $cmd, $type, $text, $warn ) = @_;
+
+    $cmd->{req_valid} = 0;
+    $cmd->{err_type}  = $type;
+    $cmd->{err_text}  = $text;
+
+    $cmd->{warn} = $warn
+      if $warn;
+
+    return $cmd;
+}
+
+1;

--- a/Koha/Plugin/Com/Theke/SLNP/lib/SLNP/Server.pm
+++ b/Koha/Plugin/Com/Theke/SLNP/lib/SLNP/Server.pm
@@ -41,6 +41,7 @@ use DateTime;
 
 # each real SLNP command is handled in an individual perl module
 use SLNP::Commands::Bestellung;
+use SLNP::Commands::DatenAenderung;
 
 use SLNP::Normalizer qw();
 
@@ -114,6 +115,15 @@ my $SlnpErr2HttpCode = {
         code => 510,
         text => undef,
     },
+    SLNP_PFL_NOT_EXISTING => {
+        'code' => 510,
+        'text' => 'PFLNummerNichtVorhanden'
+    },
+    SLNP_PFL_NOT_PLAUSIBLE => {
+        'code' => 510,
+        'text' => 'PFLNummerNichtPlausibel'
+    },
+
 };
 
 my $SLNPCmds = {
@@ -413,6 +423,28 @@ my $SLNPCmds = {
     'SLNPQuit' => {
 
         # special command managed internally
+    },
+        'SLNPPFLDatenAenderung' => {
+        'slnpparams' => {
+
+            # <call number>
+            'Signatur' => {
+                'level' => 1,
+                'regex' => '^\s*(.+)$',
+            },
+            # <org code giving library >
+            'SigelGB' => {
+                'level' => 1,
+                'regex' => '^\s*(.+)$',
+            },
+            # koha ill request id
+            'PFLNummer' => {
+                'level' => 1,
+                'regex' => '^\s*(.+)\s*$',
+                'mand'  => 1,
+            },  
+        },
+        'execute' => 'cmdPFLDatenAenderung',
     },
 };
 
@@ -942,6 +974,46 @@ sub readSLNPParam {
 
     return $reqParamVals;
 }
+
+sub cmdPFLDatenAenderung {
+# fix
+  my ( $self, $slnpcmd ) = @_;
+
+    $self->log(
+        3,
+        getTime() . "[SLNP::Server][DatenAenderung] " . $slnpcmd->{'cmd_name'} . ":"
+    );
+
+    my ( $cmd, $res, $conn, $request ) = undef;
+
+    my $params = undef;
+    my @fields = (
+        'PFLNummer',
+        'SigelGB',
+        'Signatur',
+    );
+
+    foreach my $field (@fields) {
+        my $param = $self->readSLNPParam( $slnpcmd, 1, $field );
+        $params->{$field} = $param->[0]->[0] if $param;
+    }
+
+    $self->log( 3, getTime() . " [SLNP::Server] > params:" . Dumper($params) );
+
+    $res = SLNP::Commands::DatenAenderung::SLNPPFLDatenAenderung( $slnpcmd, $params );
+
+    $self->log(
+        3,
+        getTime()
+            . " [SLNP::Server] SLNPFLBestellung has returned, res->{'cmd_name'}:"
+            . $res->{'cmd_name'}
+            . ":, res->{'req_valid'}:"
+            . $res->{'req_valid'}
+    );
+
+    return $slnpcmd;
+}
+
 
 sub cmdFLBestellung {
     my ( $self, $slnpcmd ) = @_;

--- a/Koha/Plugin/Com/Theke/SLNP/lib/SLNP/Server.pm
+++ b/Koha/Plugin/Com/Theke/SLNP/lib/SLNP/Server.pm
@@ -1018,6 +1018,8 @@ sub cmdPFLDatenAenderung {
 sub cmdFLBestellung {
     my ( $self, $slnpcmd ) = @_;
 
+    my $configuration = Koha::Plugin::Com::Theke::SLNP->new->configuration;
+
     $self->log(
         3,
         getTime() . "[SLNP::Server][Bestellung] " . $slnpcmd->{'cmd_name'} . ":"
@@ -1063,6 +1065,43 @@ sub cmdFLBestellung {
     $self->log( 3, getTime() . " [SLNP::Server] > params:" . Dumper($params) );
 
     $res = SLNP::Commands::Bestellung::SLNPFLBestellung( $slnpcmd, $params );
+
+    # mail staff
+    if (   $res->{'req_valid'}
+        && $params->{'BsTyp'} eq 'AFL'
+        && $configuration->{accepted_afl_notice}
+        && C4::Context->preference('ILLDefaultStaffEmail') )
+    {
+
+        my $email     = C4::Context->preference('ILLDefaultStaffEmail');
+        my $pflnummer = $res->{rsp_para}->[0]->{resp_pval};
+
+        my %substitute =
+            ( pflnummer => $pflnummer, bestellid => $params->{BestellId}, portal => $configuration->{'portal_url'} );
+
+        my $letter = C4::Letters::GetPreparedLetter(
+            module                 => 'ill',
+            letter_code            => 'AFL_ORDER_CREATED',
+            message_transport_type => 'email',
+            substitute             => \%substitute,
+        );
+
+        if ($letter) {
+            C4::Letters::EnqueueLetter(
+                {
+                    letter                 => $letter,
+                    message_transport_type => 'email',
+                    to_address             => $email
+                }
+            );
+
+            $self->log(
+                3,
+                getTime() . "[SLNP::Server][Bestellung] AFL notification sent to " . $email . ":"
+            );
+        }
+
+    }
 
     $self->log(
         3,

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ lending:
   control_borrowernumber: 123
   accepts_hold_requests: true
 not_for_loan_after_auto_checkin: 1
+lending_library:
+  search_prefix: "<"
+  search_suffix: ">"
+  # where the sigel of the library is stored : surname || firstname || middle_name || othernames
+  ill_library_id: "surname"
 ```
 
 ### not_for_loan_after_auto_checkin

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ lending_library:
   search_suffix: ">"
   # where the sigel of the library is stored : surname || firstname || middle_name || othernames
   ill_library_id: "surname"
+accepted_afl_notice: 1 # see letters.md  for more information
 ```
 
 ### not_for_loan_after_auto_checkin

--- a/letters.md
+++ b/letters.md
@@ -1,0 +1,23 @@
+# Benachrichtigungen Gebende Fernleihe
+
+## AFL_ORDER_CREATED
+
+Dieser Druck wird bei Eingangsverbuchung einer aktiven (gebenden) Fernleihe angestoßen, wenn in der Plugin-Konfiguration der Wert `accepted_afl_notice:1` gesetzt ist. Zusätzlich muss der Systemparameter `ILLDefaultStaffEmail` als Zieladresse der Benachrichtigung angegeben sein. 
+
+### Message subject
+
+`AFL Bestellung [% bestellid %]`
+
+### Body
+
+- email (ILLDefaultStaffEmail)
+
+```
+AFL Bestellung mit folgender BestellId eingegangen: [% bestellid %]
+
+https://zfl-prod.bsz-bw.de/flcgi/zflhistory.pl?BestellId=[% bestellid %]
+
+[% portal %]/flcgi/zflhistory.pl?BestellId=[% bestellid %]
+
+AFL der nehmenden Bibliothek: [% pflnummer %]
+```


### PR DESCRIPTION
This patch introduces the command SLNPPFLDatenAenderung to change incoming items attributes referenced by PFL number.

This attributes could be

- sigel_lending_library (SigelGB) -> to map the Koha::Patron
- itemcallnumber (Signatur)

Readme is updated with new lending_library config section which defines where to look for the given SigelGB in Koha::Patrons

When pfl_number_prefix is set to @ the zfl server will omit it when sending a DatenAenderung requests. It will then send only the ill request id. So when pfl_number_prefix is set to @ we check only for numerical values in param PFLNummer. Else the whole prefix and number get evaluated.

The lending library will be displayed in the Details from supplier section